### PR TITLE
Changes to allow doctrine/dbal 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require": {
     "php": "^8.0",
-    "doctrine/dbal": "^3.3",
+    "doctrine/dbal": "^4.1",
     "jawira/the-lost-functions": "^1.1"
   },
   "require-dev": {

--- a/src/Relational/Column.php
+++ b/src/Relational/Column.php
@@ -3,6 +3,7 @@
 namespace Jawira\DbDraw\Relational;
 
 use Doctrine\DBAL\Schema\Column as DoctrineColumn;
+use Doctrine\DBAL\Types\Type;
 
 use function vsprintf;
 use const PHP_EOL;
@@ -22,7 +23,7 @@ class Column implements ElementInterface
     $chunks = [
       $this->doctrineColumn->getNotnull() ? '*' : '',
       $this->doctrineColumn->getName(),
-      $this->doctrineColumn->getType()->getName(),
+      Type::getTypeRegistry()->lookupName($this->doctrineColumn->getType()),
     ];
 
     return vsprintf($format, $chunks) . PHP_EOL;


### PR DESCRIPTION
I have tried to make changes to allow the usage of doctrine/dbal 4.

getName() of Doctrine/Type was removed in dbal 4 (already deprecated in dbal 3), so I replaced it with TypeRegistry::lookup() which should do the job.
I don't know if running Type::getTypeRegistry for each column is a little too much overhead or if this should just be issued once and the object reused, but I didn't dive deep enough into the package to find out the necessary changes - you decide :)

Successfully tested this with one of my projects, please let me know what you think.